### PR TITLE
chore: Update @hemilabs/universal-router-sdk version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist
 lib/types
 cache
 .idea
+api/.esbuild
 api/.serverless
 api/.esbuild
 !api/.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hapi/joi": "^17.1.1",
         "@hemilabs/sdk-core": "4.2.0-beta.2",
         "@hemilabs/smart-order-router": "3.26.1-beta.1",
-        "@hemilabs/universal-router-sdk": "1.8.2-beta.1",
+        "@hemilabs/universal-router-sdk": "1.8.2-beta.3",
         "@middy/core": "^2.4.1",
         "@middy/http-error-handler": "^2.4.1",
         "@middy/http-json-body-parser": "^2.4.1",
@@ -3383,9 +3383,9 @@
       }
     },
     "node_modules/@hemilabs/universal-router-sdk": {
-      "version": "1.8.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@hemilabs/universal-router-sdk/-/universal-router-sdk-1.8.2-beta.1.tgz",
-      "integrity": "sha512-ZqOndp1iA+aHMWt7JMWGNlXCPgXFhDKtJz111LJs8vB706QK7ib+mE5K5kyS5DrRP45kWSdQulI4tCXSdXsO4A==",
+      "version": "1.8.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@hemilabs/universal-router-sdk/-/universal-router-sdk-1.8.2-beta.3.tgz",
+      "integrity": "sha512-QYF3vYspapanM1hJ6XWm6Q575d34PxPutqYC2ylOpdCpC735kq4XDRVxffvAtO5PgPk7NKbxOrQeCIKzDMOsmw==",
       "dependencies": {
         "@hemilabs/sdk-core": "4.2.0-beta.2",
         "@uniswap/permit2-sdk": "^1.2.0",
@@ -33771,9 +33771,9 @@
       }
     },
     "@hemilabs/universal-router-sdk": {
-      "version": "1.8.2-beta.1",
-      "resolved": "https://registry.npmjs.org/@hemilabs/universal-router-sdk/-/universal-router-sdk-1.8.2-beta.1.tgz",
-      "integrity": "sha512-ZqOndp1iA+aHMWt7JMWGNlXCPgXFhDKtJz111LJs8vB706QK7ib+mE5K5kyS5DrRP45kWSdQulI4tCXSdXsO4A==",
+      "version": "1.8.2-beta.3",
+      "resolved": "https://registry.npmjs.org/@hemilabs/universal-router-sdk/-/universal-router-sdk-1.8.2-beta.3.tgz",
+      "integrity": "sha512-QYF3vYspapanM1hJ6XWm6Q575d34PxPutqYC2ylOpdCpC735kq4XDRVxffvAtO5PgPk7NKbxOrQeCIKzDMOsmw==",
       "requires": {
         "@hemilabs/sdk-core": "4.2.0-beta.2",
         "@uniswap/permit2-sdk": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@hemilabs/sdk-core": "4.2.0-beta.2",
     "@hemilabs/smart-order-router": "3.26.1-beta.1",
     "@uniswap/token-lists": "^1.0.0-beta.33",
-    "@hemilabs/universal-router-sdk": "1.8.2-beta.1",
+    "@hemilabs/universal-router-sdk": "1.8.2-beta.3",
     "@uniswap/v2-sdk": "^4.3.0",
     "@uniswap/v3-periphery": "^1.4.4",
     "@uniswap/v3-sdk": "^3.11.0",


### PR DESCRIPTION
Updates the `@hemilabs/universal-router-sdk` to use the one that has the correct version of the Universal Router address 