### PR TITLE
Fix CORS

### DIFF
--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -13,10 +13,20 @@ custom:
 functions:
   get-quote:
     events:
-      - http: 
+      - http:
           method: post
           path: /v2/quote
-          cors: true
+          cors:
+            origin: '*'
+            headers:
+              - Content-Type
+              - X-Amz-Date
+              - Authorization
+              - X-Api-Key
+              - X-Amz-Security-Token
+              - X-Amz-User-Agent
+              - x-request-source
+            allowCredentials: false
     handler: ./index.post
     timeout: 30
 


### PR DESCRIPTION
From the uniswap interface, we're getting this cors error:
<img width="666" alt="Captura de pantalla 2024-04-30 a la(s) 16 10 11" src="https://github.com/hemilabs/routing-api/assets/1864435/3cd4f5a9-b2e7-4ba4-838f-b41b4e2b35e3">

The app is actually adding a request header `x-request-source`, so we need to add it to `access-control-allow-headers
	`  
<img width="632" alt="Captura de pantalla 2024-04-30 a la(s) 16 10 25" src="https://github.com/hemilabs/routing-api/assets/1864435/469d1b1e-c135-4087-b123-f100f6e49ae5">
