### PR TITLE
Make recipient an optional param

### DIFF
--- a/lib/handlers/quote/schema/quote-schema.ts
+++ b/lib/handlers/quote/schema/quote-schema.ts
@@ -145,7 +145,7 @@ export const HemiQuoteQueryParamsJoi = Joi.object({
         // Frontend sends multiple unsupported protocols, but we just support V3
         // which is enforced in our api.
         protocols: Joi.array().items(Joi.string()).required(),
-        recipient: Joi.string().alphanum().max(42).required(),
+        recipient: Joi.string().alphanum().max(42).optional(),
         routingType: Joi.string().optional(),
       })
     )


### PR DESCRIPTION
Calls from the HEMI swap web application were failing because the "recipient" parameter was required by the API but not sent by the app. After a quick analysis, it looks like that parameter may be omitted safely so this PR changes it to "optional" so calls no longer fail.