### PR TITLE
Use the public Hemi Sepolia RPC URL

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -1,1 +1,1 @@
-WEB3_RPC_743111="https://int02.testnet.rpc.hemi.network/rpc"
+WEB3_RPC_743111="https://testnet.rpc.hemi.network/rpc"


### PR DESCRIPTION
Just update the `.env` file.

The env var in GitHub Actions secrets was also updated but it doesn't seem to be used at all.